### PR TITLE
static-declarative-project: fix configuration

### DIFF
--- a/static-declarative-project/declarative.json
+++ b/static-declarative-project/declarative.json
@@ -1,7 +1,7 @@
 {
   "nixpkgs": {
     "enabled": 1,
-    "visible": true,
+    "hidden": false,
     "description": "Nixpkgs",
     "nixexprinput": "nixpkgs",
     "nixexprpath": "pkgs/top-level/release.nix",
@@ -20,7 +20,7 @@
   },
   "nixos": {
     "enabled": 1,
-    "visible": true,
+    "hidden": false,
     "description": "NixOS: Small Evaluation",
     "nixexprinput": "nixpkgs",
     "nixexprpath": "nixos/release-small.nix",


### PR DESCRIPTION
Fixes the following error:

    12:06:21 hydra-evaluator.1    | ERROR: failed to process declarative jobset nixpkgs:nixos, {UNKNOWN}: invalid keys (
    HASH(0x6f4f8b8)) in declarative specification file at /nix/store/yzgayml6kbsq4i4x96gvvq9g6my4z790-hydra-perl-deps/lib
    /perl5/site_perl/5.32.0/Catalyst/Model/DBIC/Schema.pm line 526